### PR TITLE
Add fix to record parameters with default values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ public class MyClass
 
 **How it helps engineering**: See SE1030
 
+#### SE1034: PrimaryDefaultConstructorValuesNotAllowed
+
+**What it looks for**: Primary constructors are not allowed to have default values on implicit constructor properties.
+
+**Why**: Default arguments on the primary constructor are not allowed on exhauste initialization types.
+
+**How it helps engineering**: See SE1030
 
 
 #### Code fix available

--- a/src/SubtleEngineering.Analyzers.Tests/ExhaustiveInitialization/ExhaustiveInitializationCodeFixTests.cs
+++ b/src/SubtleEngineering.Analyzers.Tests/ExhaustiveInitialization/ExhaustiveInitializationCodeFixTests.cs
@@ -6,6 +6,7 @@ using VerifyCf = CSharpCodeFixVerifier<ExhaustiveInitializationAnalyzer, Exhaust
 using SubtleEngineering.Analyzers.Decorators;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft;
 
 public class ExhaustiveInitializationCodeFixTests
 {
@@ -52,14 +53,51 @@ public class ExhaustiveInitializationCodeFixTests
         await sut.RunAsync();
     }
 
-    [Fact(Skip = "In UTs modifies one of the props with two required")]
+    [Fact]
+    public async Task RemoveDefaultValue()
+    {
+        string code = $$"""
+            namespace A
+            {
+                [SubtleEngineering.Analyzers.Decorators.ExhaustiveInitialization]
+                record AllPropsB(int MyInt = 0)
+                {
+                }
+            }
+            """;
+
+        const string fixedCode = """
+            namespace A
+            {
+                [SubtleEngineering.Analyzers.Decorators.ExhaustiveInitialization]
+                record AllPropsB(int MyInt )
+                {
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = [
+            VerifyCf.Diagnostic(
+                ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.TypeInitializationIsNonExhaustiveId))
+                    .WithLocation(4, 12)
+                    .WithArguments("A.AllPropsB"),
+            VerifyCf.Diagnostic(
+                ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.PrimaryDefaultConstructorValuesNotAllowedId))
+                    .WithLocation(4, 22)
+                    .WithArguments("A.AllPropsB", "MyInt"),
+            ];
+        var sut = CreateSut(code, fixedCode, DiagnosticsDetails.ExhaustiveInitialization.ParameterEquivalenceKey, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact(Skip = "For some reason emits two required in the fix")]
     public async Task FixEntireType()
     {
         string code = $$"""
             namespace A
             {
                 [SubtleEngineering.Analyzers.Decorators.ExhaustiveInitialization]
-                class AllPropsB
+                record AllPropsB(double MyDouble = 1.0)
                 {
                     public int MyInt { get; set; }
                     public string MyString { get; set; }
@@ -72,7 +110,7 @@ public class ExhaustiveInitializationCodeFixTests
             namespace A
             {
                 [SubtleEngineering.Analyzers.Decorators.ExhaustiveInitialization]
-                class AllPropsB
+                record AllPropsB(double MyDouble )
                 {
                     required public int MyInt { get; set; }
                     required required public string MyString { get; set; }
@@ -83,7 +121,7 @@ public class ExhaustiveInitializationCodeFixTests
         List<DiagnosticResult> expected = [
             VerifyCf.Diagnostic(
                 ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.TypeInitializationIsNonExhaustiveId))
-                    .WithLocation(4, 11)
+                    .WithLocation(4, 12)
                     .WithArguments("A.AllPropsB"),
             VerifyCf.Diagnostic(
                 ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.PropertyIsMissingRequiredId))
@@ -93,6 +131,10 @@ public class ExhaustiveInitializationCodeFixTests
                 ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.PropertyIsMissingRequiredId))
                     .WithLocation(7, 23)
                     .WithArguments("A.AllPropsB", "MyString"),
+            VerifyCf.Diagnostic(
+                ExhaustiveInitializationAnalyzer.Rules.Find(DiagnosticsDetails.ExhaustiveInitialization.PrimaryDefaultConstructorValuesNotAllowedId))
+                    .WithLocation(4, 22)
+                    .WithArguments("A.AllPropsB", "MyDouble"),
             ];
         var sut = CreateSut(code, fixedCode, DiagnosticsDetails.ExhaustiveInitialization.TypeEquivalenceKey, expected);
         await sut.RunAsync();
@@ -163,12 +205,13 @@ public class ExhaustiveInitializationCodeFixTests
             },
 
         };
+
         test.CodeActionEquivalenceKey = equivalenceKey;
         test.ExpectedDiagnostics.AddRange(expected);
-        test.NumberOfFixAllIterations = 1;
-        test.NumberOfFixAllInDocumentIterations = 1;
-        test.NumberOfFixAllInProjectIterations = 1;
-        test.CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne;
+        //test.NumberOfFixAllIterations = 1;
+        //test.NumberOfFixAllInDocumentIterations = 1;
+        //test.NumberOfFixAllInProjectIterations = 1;
+        //test.CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne;
 
         return test;
     }

--- a/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
+++ b/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
@@ -27,13 +27,16 @@
             public const string PropertyIsMissingRequiredId = "SE1031";
             public const string OnlyOneConstructorAllowedId = "SE1032";
             public const string NotAllowedOnTypeId = "SE1033";
+            public const string PrimaryDefaultConstructorValuesNotAllowedId = "SE1034";
 
             public const string PrimaryCtorOnNonRecordReason = "primary constructors on classes and structs cannot be analyzed for assignment to non-required properties. Use a regular constructor if you need to initialize properties that are not set as required.";
 
             public const string PropertyEquivalenceKey = "Property";
             public const string TypeEquivalenceKey = "Property";
+            public const string ParameterEquivalenceKey = "Parameter";
 
             public const string BadPropertyPrefix = "BadProperty_";
+            public const string BadParameterPrefix = "BadParameter_";
         }
     }
 }

--- a/src/SubtleEngineering.Analyzers/ExhaustiveInitialization/ExhaustiveInitializationCodeFix.cs
+++ b/src/SubtleEngineering.Analyzers/ExhaustiveInitialization/ExhaustiveInitializationCodeFix.cs
@@ -56,7 +56,7 @@
                     // Register a code action that will invoke the fix.
                     context.RegisterCodeFix(
                         CodeAction.Create(
-                            title: "Make all properties required",
+                            title: "Make type exhaustive",
                             createChangedDocument: c => FixEntireType(context, typeSyntax, diagnostic, c),
                             equivalenceKey: DiagnosticsDetails.ExhaustiveInitialization.TypeEquivalenceKey),
                         diagnostic);
@@ -69,7 +69,7 @@
                     // Register a code action that will invoke the fix.
                     context.RegisterCodeFix(
                         CodeAction.Create(
-                            title: "Make type exhaustive",
+                            title: "Remove default parameter/proprerty value",
                             createChangedDocument: c => FixParameter(context, paramSyntax, diagnostic, c),
                             equivalenceKey: DiagnosticsDetails.ExhaustiveInitialization.ParameterEquivalenceKey),
                         diagnostic);

--- a/src/SubtleEngineering.Analyzers/ExhaustiveInitialization/ExhaustiveInitializationCodeFix.cs
+++ b/src/SubtleEngineering.Analyzers/ExhaustiveInitialization/ExhaustiveInitializationCodeFix.cs
@@ -17,7 +17,10 @@
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ExhaustiveInitializationCodeFix)), Shared]
     public class ExhaustiveInitializationCodeFix : CodeFixProvider
     {
-        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticsDetails.ExhaustiveInitialization.PropertyIsMissingRequiredId, DiagnosticsDetails.ExhaustiveInitialization.TypeInitializationIsNonExhaustiveId);
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+            DiagnosticsDetails.ExhaustiveInitialization.PropertyIsMissingRequiredId,
+            DiagnosticsDetails.ExhaustiveInitialization.TypeInitializationIsNonExhaustiveId,
+            DiagnosticsDetails.ExhaustiveInitialization.PrimaryDefaultConstructorValuesNotAllowedId);
 
         public override FixAllProvider GetFixAllProvider()
         {
@@ -27,7 +30,7 @@
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(x => x.Id == DiagnosticsDetails.ExhaustiveInitialization.PropertyIsMissingRequiredId || x.Id == DiagnosticsDetails.ExhaustiveInitialization.TypeInitializationIsNonExhaustiveId))
+            foreach (var diagnostic in context.Diagnostics.Where(x => x.Id.StartsWith("SE")))
             {
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
 
@@ -58,7 +61,39 @@
                             equivalenceKey: DiagnosticsDetails.ExhaustiveInitialization.TypeEquivalenceKey),
                         diagnostic);
                 }
+                else if (diagnostic.Id == DiagnosticsDetails.ExhaustiveInitialization.PrimaryDefaultConstructorValuesNotAllowedId)
+                {
+                    var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+                    var paramSyntax = root.FindNode(diagnosticSpan).FirstAncestorOrSelf<ParameterSyntax>();
+
+                    // Register a code action that will invoke the fix.
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            title: "Make type exhaustive",
+                            createChangedDocument: c => FixParameter(context, paramSyntax, diagnostic, c),
+                            equivalenceKey: DiagnosticsDetails.ExhaustiveInitialization.ParameterEquivalenceKey),
+                        diagnostic);
+                }
             }
+        }
+
+        private async Task<Document> FixParameter(CodeFixContext context, ParameterSyntax paramSyntax, Diagnostic diagnostic, CancellationToken ct)
+        {
+            var document = context.Document;
+            var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
+
+            // Add the 'required' modifier to the member declaration
+            var newParamSyntax = GetFixedParameter(paramSyntax);
+
+            var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            var newRoot = root.ReplaceNode(paramSyntax, newParamSyntax);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private ParameterSyntax GetFixedParameter(ParameterSyntax paramSyntax)
+        {
+            return paramSyntax.WithDefault(null);
         }
 
         private async Task<Document> FixProperty(CodeFixContext context, MemberDeclarationSyntax memberDeclarationSyntax, Diagnostic diagnostic, CancellationToken ct)
@@ -106,6 +141,27 @@
                 // Add the 'required' modifier to the member declaration
                 var newMember = GetFixedProperty(member);
                 editor.ReplaceNode(member, newMember);
+            }
+
+            // Find all relevant properties.
+            var parametersToFix = diagnostic
+                .Properties
+                .Where(x => x.Key.StartsWith(DiagnosticsDetails.ExhaustiveInitialization.BadParameterPrefix))
+                .Select(x => x.Value)
+                .ToArray();
+
+            if (typeSyntax is RecordDeclarationSyntax recordDeclaration)
+            {
+                var constructorParameters = recordDeclaration
+                    .ParameterList
+                    .Parameters
+                    .ToArray() ?? Array.Empty<ParameterSyntax>();
+
+                foreach (var prop in constructorParameters)
+                {
+                    var newMember = GetFixedParameter(prop);
+                    editor.ReplaceNode(prop, newMember);
+                }
             }
             var newRoot = editor.GetChangedRoot();
             var newDocument = document.WithSyntaxRoot(newRoot);


### PR DESCRIPTION
#### SE1034: PrimaryDefaultConstructorValuesNotAllowed

**What it looks for**: Primary constructors are not allowed to have default values on implicit constructor properties.

**Why**: Default arguments on the primary constructor are not allowed on exhauste initialization types.

**How it helps engineering**: See SE1030