### PR TITLE
Add option for keeping obsolete members visible.

### DIFF
--- a/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
+++ b/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
@@ -42,6 +42,9 @@
         public class Obsolescence // TVM 1040+
         {
             public const string HideObsoleteElementsId = "SE1040";
+
+            public const string HideEquivalenceKey = "AddHideEditorBrowsableAttribute";
+            public const string KeepEquivalenceKey = "AddKeepEditorBrowsableAttribute";
         }
 
         public class ExhaustiveEnumSwitch

--- a/src/SubtleEngineering.Analyzers/Obsolescence/CorrectObsolescenceCodeFix.cs
+++ b/src/SubtleEngineering.Analyzers/Obsolescence/CorrectObsolescenceCodeFix.cs
@@ -55,12 +55,18 @@
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: "Hide obsolete element from IntelliSense",
-                    createChangedDocument: c => AddEditorBrowsableAttributeAsync(context.Document, declarationNode, c),
-                    equivalenceKey: "AddEditorBrowsableAttribute"),
+                    createChangedDocument: c => AddEditorBrowsableAttributeAsync(context.Document, declarationNode, c, true),
+                    equivalenceKey: DiagnosticsDetails.Obsolescence.HideEquivalenceKey),
+                diagnostic);
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Keep obsolete element visible for IntelliSense",
+                    createChangedDocument: c => AddEditorBrowsableAttributeAsync(context.Document, declarationNode, c, false),
+                    equivalenceKey: DiagnosticsDetails.Obsolescence.KeepEquivalenceKey),
                 diagnostic);
         }
 
-        private async Task<Document> AddEditorBrowsableAttributeAsync(Document document, SyntaxNode declarationNode, CancellationToken cancellationToken)
+        private async Task<Document> AddEditorBrowsableAttributeAsync(Document document, SyntaxNode declarationNode, CancellationToken cancellationToken, bool hide)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
@@ -82,7 +88,7 @@
                             SyntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 SyntaxFactory.IdentifierName("EditorBrowsableState"),
-                                SyntaxFactory.IdentifierName("Never"))))));
+                                SyntaxFactory.IdentifierName(hide ? "Never" : "Always"))))));
 
             var newAttributeList = SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(editorBrowsableAttribute));
 


### PR DESCRIPTION
When fixing obsolete methods with no EdtitorBrowsable attributes on them, the developer now has the option of keeping element visible for intellisense.