### PR TITLE
SE106X - Force parameters properties and fields to hold static lambdas/methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,39 @@ var x = e.ForceExhaustive() switch
 	MyEnum.Value1 and MyEnum.Value2 => // Disallowed and doesnt make sense.
 	etc...
 }
+```
+
+### Code quality: Warn against using non-static lambdas (SE106X)
+
+For performance-sensitive code, it's sometimes useful for the developer to prevent misuse of a method or class to protect the developer.
+
+Using the [UseStaticLambda] on a field, property or parameter will cause the analyzer to emit a warning if a non-static lambda is passed in.
+
+```csharp
+public ref struct MyOptimizedNonAllocUtility
+{
+	public MyOptimizedNonAllocUtility([UseStaticLambda] Func<int> myDelegate)
+	{
+		_myDelegate = myDelegate;
+	}
+}
+
+// Code using the struct
+var s = new MyOptimizedNonAllocUtility(() => 42); // This will emit SE1060
+
+// Fixed code:
+var s = new MyOptimizedNonAllocUtility(static () => 42); // This will emit SE1060
+
+
+```
+
+#### SE1060/SE1061
+
+**What it looks for**: Passing in non-static delegates to methods that expect to get a static.
+
+**Why**: For performance-sensitive code that uses delegates, it's easy to sometimes forget that creating a capturing delegate can be expensive. This will remind the developer to use a delegate that will not allocate or allocate less.
+
+**How it helps engineers**: Reduces the chance of making such mistakes.
+
+
 

--- a/src/SubtleEngineering.Analyzers.Decorators/UseStaticLambdaAttribute.cs
+++ b/src/SubtleEngineering.Analyzers.Decorators/UseStaticLambdaAttribute.cs
@@ -1,0 +1,19 @@
+﻿namespace SubtleEngineering.Analyzers.Decorators
+{
+    using System;
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+    public class UseStaticLambdaAttribute : Attribute
+    {
+        public UseStaticLambdaAttribute()
+        {
+        }
+
+        public UseStaticLambdaAttribute(string reasoning)
+        {
+            Reasoning = reasoning;
+        }
+
+        public string Reasoning { get; }
+    }
+}

--- a/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
+++ b/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
@@ -49,7 +49,7 @@ public class UseStaticLambdaOrMethodAnalyzerTests
             public class MyClass
             {
                 public static void DoIt(
-                    [UseStaticLambda("Ensure performance optimization")]
+                    [UseStaticLambda]
                     Func<int> lambda)
                 {
                     lambda();
@@ -68,9 +68,9 @@ public class UseStaticLambdaOrMethodAnalyzerTests
         List<DiagnosticResult> expected = new List<DiagnosticResult>
         {
             VerifyCS.Diagnostic(
-                UseStaticLambdaOrMethodAnalyzer.Rules[1])
-                    .WithLocation(14, 22)
-                    .WithArguments("MyLambda", "Ensure performance optimization")
+                UseStaticLambdaOrMethodAnalyzer.Rules[0])
+                    .WithLocation(17, 22)
+                    .WithArguments("lambda")
         };
         var sut = CreateSut(code, expected);
         await sut.RunAsync();
@@ -101,7 +101,7 @@ public class UseStaticLambdaOrMethodAnalyzerTests
         {
             VerifyCS.Diagnostic(
                 UseStaticLambdaOrMethodAnalyzer.Rules[1])
-                    .WithLocation(14, 22)
+                    .WithLocation(6, 47)
                     .WithArguments("MyLambda", "Ensure performance optimization")
         };
         var sut = CreateSut(code, expected);
@@ -131,6 +131,161 @@ public class UseStaticLambdaOrMethodAnalyzerTests
             """;
 
         List<DiagnosticResult> expected = new List<DiagnosticResult>();
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_WithField()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda]
+                public Func<int> MyLambdaField;
+            }
+            
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambdaField = () => 42;
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[0])
+                    .WithLocation(14, 27)
+                    .WithArguments("MyLambdaField")
+        };
+        var sut = CreateSut(code, expected); await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_WithImplicitDelegate()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda]
+                public Func<int> MyLambdaField;
+            }
+            
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambdaField = MyFunc;
+                }
+
+                public int MyFunc() => 42;
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[0])
+                    .WithLocation(14, 27)
+                    .WithArguments("MyLambdaField")
+        };
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_WithImplicitStaticDelegate()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda]
+                public Func<int> MyLambdaField;
+            }
+            
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambdaField = MyFunc;
+                }
+
+                public static int MyFunc() => 42;
+            }
+            """;
+
+        var sut = CreateSut(code, []);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_WithField_WhenStatic()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda("Ensure performance optimization")]
+                public Func<int> MyLambdaField;
+            }
+            
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambdaField = static () => 42;
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>();
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_WithFieldInitializer()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda]
+                public Func<int> MyLambdaField = () => 42;
+            }
+            
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambdaField = () => 42;
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[0])
+                    .WithLocation(14, 27)
+                    .WithArguments("MyLambdaField")
+        };
         var sut = CreateSut(code, expected);
         await sut.RunAsync();
     }

--- a/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
+++ b/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
@@ -33,7 +33,75 @@ public class UseStaticLambdaOrMethodAnalyzerTests
         {
             VerifyCS.Diagnostic(
                 UseStaticLambdaOrMethodAnalyzer.Rules[1])
-                    .WithLocation(6, 22)
+                    .WithLocation(14, 22)
+                    .WithArguments("MyLambda", "Ensure performance optimization")
+        };
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNonStaticLambdaParameterUsage()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                public static void DoIt(
+                    [UseStaticLambda("Ensure performance optimization")]
+                    Func<int> lambda)
+                {
+                    lambda();
+                }
+            }
+
+            public class Program
+            {
+                public void Main()
+                {
+                    MyClass.DoIt(() => 42);
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[1])
+                    .WithLocation(14, 22)
+                    .WithArguments("MyLambda", "Ensure performance optimization")
+        };
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNonStaticLambdaUsageWhenInitializing()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda("Ensure performance optimization")]
+                public Func<int> MyLambda { get; set; } = () => 42;
+            }
+
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[1])
+                    .WithLocation(14, 22)
                     .WithArguments("MyLambda", "Ensure performance optimization")
         };
         var sut = CreateSut(code, expected);

--- a/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
+++ b/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
@@ -1,10 +1,9 @@
 ﻿namespace SubtleEngineering.Analyzers.Tests.UseStaticLambda;
 
-using VerifyCS = CSharpAnalyzerVerifier<UseDifferentMethod.UseStaticLambdaOrMethodAnalyzer>;
+using VerifyCS = CSharpAnalyzerVerifier<UseStaticLambdaOrMethodAnalyzer>;
 using SubtleEngineering.Analyzers.Decorators;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis;
-using SubtleEngineering.Analyzers.UseDifferentMethod;
 
 public class UseStaticLambdaOrMethodAnalyzerTests
 {
@@ -17,7 +16,7 @@ public class UseStaticLambdaOrMethodAnalyzerTests
             public class MyClass
             {
                 [UseStaticLambda("Ensure performance optimization")]
-                public Func<int> MyLambda { get; set; } = () => 42; // Non-static lambda
+                public Func<int> MyLambda { get; set; }
             }
 
             public class Program
@@ -33,9 +32,9 @@ public class UseStaticLambdaOrMethodAnalyzerTests
         List<DiagnosticResult> expected = new List<DiagnosticResult>
         {
             VerifyCS.Diagnostic(
-                UseStaticLambdaOrMethodAnalyzer.Rules[0])
-                    .WithLocation(5, 44)
-                    .WithArguments("MyLambda")
+                UseStaticLambdaOrMethodAnalyzer.Rules[1])
+                    .WithLocation(6, 22)
+                    .WithArguments("MyLambda", "Ensure performance optimization")
         };
         var sut = CreateSut(code, expected);
         await sut.RunAsync();
@@ -50,12 +49,12 @@ public class UseStaticLambdaOrMethodAnalyzerTests
             public class MyClass
             {
                 [UseStaticLambda("Ensure performance optimization")]
-                public Func<int> MyLambda { get; set; } = () => 42; // Non-static lambda
+                public Func<int> MyLambda { get; set; }
             }
             
             public class Program
             {
-                public Main()
+                public void Main()
                 {
                     var c = new MyClass();
                     c.MyLambda = static () => 42;

--- a/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
+++ b/src/SubtleEngineering.Analyzers.Tests/UseStaticLambda/UseStaticLambdaAnalyzerTests.cs
@@ -1,0 +1,90 @@
+﻿namespace SubtleEngineering.Analyzers.Tests.UseStaticLambda;
+
+using VerifyCS = CSharpAnalyzerVerifier<UseDifferentMethod.UseStaticLambdaOrMethodAnalyzer>;
+using SubtleEngineering.Analyzers.Decorators;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis;
+using SubtleEngineering.Analyzers.UseDifferentMethod;
+
+public class UseStaticLambdaOrMethodAnalyzerTests
+{
+    [Fact]
+    public async Task TestNonStaticLambdaUsage()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda("Ensure performance optimization")]
+                public Func<int> MyLambda { get; set; } = () => 42; // Non-static lambda
+            }
+
+            public class Program
+            {
+                public void Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambda = () => 42;
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>
+        {
+            VerifyCS.Diagnostic(
+                UseStaticLambdaOrMethodAnalyzer.Rules[0])
+                    .WithLocation(5, 44)
+                    .WithArguments("MyLambda")
+        };
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStaticLambdaUsage_NoDiagnostic()
+    {
+        const string code = """
+            using SubtleEngineering.Analyzers.Decorators;
+            using System;
+            public class MyClass
+            {
+                [UseStaticLambda("Ensure performance optimization")]
+                public Func<int> MyLambda { get; set; } = () => 42; // Non-static lambda
+            }
+            
+            public class Program
+            {
+                public Main()
+                {
+                    var c = new MyClass();
+                    c.MyLambda = static () => 42;
+                }
+            }
+            """;
+
+        List<DiagnosticResult> expected = new List<DiagnosticResult>();
+        var sut = CreateSut(code, expected);
+        await sut.RunAsync();
+    }
+
+    private VerifyCS.Test CreateSut(string code, List<DiagnosticResult> expected)
+    {
+        var test = new VerifyCS.Test()
+        {
+            ReferenceAssemblies = TestHelpers.Net80,
+            TestState =
+            {
+                Sources = { code },
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(UseStaticLambdaAttribute).Assembly.Location),
+                },
+            }
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        return test;
+    }
+}

--- a/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
+++ b/src/SubtleEngineering.Analyzers/DiagnosticsDetails.cs
@@ -54,5 +54,11 @@
             public const string SwitchContainsUnsupportedPatterns = "SE1052";
 
         }
+
+        public class UseStaticLambdaOrMethod
+        {
+            public const string UseStaticNoReasoning = "SE1060";
+            public const string UseStaticWithReason = "SE1061";
+        }
     }
 }

--- a/src/SubtleEngineering.Analyzers/SubtleEngineering.Analyzers.csproj
+++ b/src/SubtleEngineering.Analyzers/SubtleEngineering.Analyzers.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <PackageVersion>$(AnalyzersVersion)</PackageVersion>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
     <PropertyGroup Label="Package Info">
         <Title>SubtleEngineering.Analyzers</Title>

--- a/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
+++ b/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
@@ -1,97 +1,107 @@
-﻿namespace SubtleEngineering.Analyzers.UseDifferentMethod
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+using SubtleEngineering.Analyzers;
+using System.Collections.Immutable;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class UseStaticLambdaOrMethodAnalyzer : DiagnosticAnalyzer
 {
-    using System;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.CSharp;
-    using System.Linq;
-    using System.Collections.Immutable;
-    using SubtleEngineering.Analyzers.Decorators;
+    private const int SE1060 = 0;
+    private const int SE1061 = 1;
 
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class UseStaticLambdaOrMethodAnalyzer : DiagnosticAnalyzer
+    public static readonly ImmutableArray<DiagnosticDescriptor> Rules = ImmutableArray.Create(
+        new DiagnosticDescriptor(
+            DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticNoReasoning,
+            "Property, field or argument should be a static lambda",
+            "Argument, property or field '{0}' should be declared as static.",
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true),
+        new DiagnosticDescriptor(
+            DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticWithReason,
+            "Property, field or argument should be a static lambda",
+            "Argument, property or field '{0}' should be declared as static. Reasoning: {1}",
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true)
+        );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Rules;
+
+    public override void Initialize(AnalysisContext context)
     {
-        private const int SE1060 = 0;
-        private const int SE1061 = 1;
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
 
-        public static readonly ImmutableArray<DiagnosticDescriptor> Rules = ImmutableArray.Create(
-            new DiagnosticDescriptor(
-                DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticNoReasoning,
-                "Property, field or argument should be a static lambda",
-                "Argument, property or field '{0}' should be declared as static.",
-                "Usage",
-                DiagnosticSeverity.Warning,
-                isEnabledByDefault: true),
-            new DiagnosticDescriptor(
-                DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticWithReason,
-                "Property, field or argument should be a static lambda",
-                "Argument, property or field '{0}' should be declared as static. Reasoning: {1}",
-                "Usage",
-                DiagnosticSeverity.Warning,
-                isEnabledByDefault: true)
-            );
+        // Register a symbol action to analyze fields, properties, and method parameters
+        context.RegisterSymbolAction(AnalyzeMember, SymbolKind.Field, SymbolKind.Property, SymbolKind.Parameter);
+    }
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Rules;
+    private static void AnalyzeMember(SymbolAnalysisContext context)
+    {
+        var symbol = context.Symbol;
+        var attributes = symbol.GetAttributes();
 
-        public override void Initialize(AnalysisContext context)
+        foreach (var attribute in attributes)
         {
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.EnableConcurrentExecution();
-
-            // Register a symbol action to analyze fields, properties, and method parameters
-            context.RegisterSymbolAction(AnalyzeMember, SymbolKind.Field, SymbolKind.Property, SymbolKind.Parameter);
-        }
-
-        private static void AnalyzeMember(SymbolAnalysisContext context)
-        {
-            var symbol = context.Symbol;
-            var attributes = symbol.GetAttributes();
-
-            foreach (var attribute in attributes)
+            if (attribute.AttributeClass?.ToDisplayString() == "SubtleEngineering.Analyzers.Decorators.UseStaticLambdaAttribute")
             {
-                if (attribute.AttributeClass?.ToDisplayString() == "SubtleEngineering.Analyzers.Decorators.UseStaticLambdaAttribute")
+                if (symbol is IFieldSymbol fieldSymbol && fieldSymbol.Type.TypeKind == TypeKind.Delegate)
                 {
-                    if (symbol is IFieldSymbol fieldSymbol && fieldSymbol.Type.TypeKind == TypeKind.Delegate)
-                    {
-                        AnalyzeLambda(fieldSymbol, context, attribute);
-                    }
-                    else if (symbol is IPropertySymbol propertySymbol && propertySymbol.Type.TypeKind == TypeKind.Delegate)
-                    {
-                        AnalyzeLambda(propertySymbol, context, attribute);
-                    }
-                    else if (symbol is IParameterSymbol parameterSymbol && parameterSymbol.Type.TypeKind == TypeKind.Delegate)
-                    {
-                        AnalyzeLambda(parameterSymbol, context, attribute);
-                    }
-
-                    return;
+                    AnalyzeLambda(fieldSymbol, context, attribute);
                 }
+                else if (symbol is IPropertySymbol propertySymbol && propertySymbol.Type.TypeKind == TypeKind.Delegate)
+                {
+                    AnalyzeLambda(propertySymbol, context, attribute);
+                }
+                else if (symbol is IParameterSymbol parameterSymbol && parameterSymbol.Type.TypeKind == TypeKind.Delegate)
+                {
+                    AnalyzeLambda(parameterSymbol, context, attribute);
+                }
+
+                return;
             }
         }
+    }
 
-        private static void AnalyzeLambda(ISymbol symbol, SymbolAnalysisContext context, AttributeData attribute)
+    private static void AnalyzeLambda(ISymbol symbol, SymbolAnalysisContext context, AttributeData attribute)
+    {
+        var reasonArg = attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value?.ToString() : null;
+        var diagnosticDescriptor = reasonArg != null ? Rules[SE1061] : Rules[SE1060];
+
+        // Check if the lambda assigned is static
+        if (symbol.DeclaringSyntaxReferences.Length > 0)
         {
-            var reasonArg = attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value?.ToString() : null;
-            var diagnosticDescriptor = reasonArg != null ? Rules[SE1061] : Rules[SE1060];
+            var syntax = symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
 
-            // Check if the lambda assigned is static
-            if (symbol.DeclaringSyntaxReferences.Length > 0)
+            if (syntax is VariableDeclaratorSyntax variableDeclarator)
             {
-                var syntax = symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
-                if (syntax is VariableDeclaratorSyntax variableDeclarator)
+                var initializer = variableDeclarator.Initializer?.Value;
+                if (initializer is SimpleLambdaExpressionSyntax lambdaExpression && !lambdaExpression.Modifiers.Any(SyntaxKind.StaticKeyword))
                 {
-                    var initializer = variableDeclarator.Initializer?.Value;
-                    if (initializer is SimpleLambdaExpressionSyntax lambdaExpression && !lambdaExpression.Modifiers.Any(SyntaxKind.StaticKeyword))
-                    {
-                        var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
-                        context.ReportDiagnostic(diagnostic);
-                    }
-                    else if (initializer is ParenthesizedLambdaExpressionSyntax parenthesizedLambda && !parenthesizedLambda.Modifiers.Any(SyntaxKind.StaticKeyword))
-                    {
-                        var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
-                        context.ReportDiagnostic(diagnostic);
-                    }
+                    var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                    context.ReportDiagnostic(diagnostic);
+                }
+                else if (initializer is ParenthesizedLambdaExpressionSyntax parenthesizedLambda && !parenthesizedLambda.Modifiers.Any(SyntaxKind.StaticKeyword))
+                {
+                    var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+            else if (syntax is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                var initializer = propertyDeclaration.Initializer?.Value;
+                if (initializer is SimpleLambdaExpressionSyntax lambdaExpression && !lambdaExpression.Modifiers.Any(SyntaxKind.StaticKeyword))
+                {
+                    var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                    context.ReportDiagnostic(diagnostic);
+                }
+                else if (initializer is ParenthesizedLambdaExpressionSyntax parenthesizedLambda && !parenthesizedLambda.Modifiers.Any(SyntaxKind.StaticKeyword))
+                {
+                    var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                    context.ReportDiagnostic(diagnostic);
                 }
             }
         }

--- a/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
+++ b/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
@@ -94,8 +94,8 @@ public class UseStaticLambdaOrMethodAnalyzer : DiagnosticAnalyzer
         var assignmentOperation = (IAssignmentOperation)context.Operation;
         ISymbol symbol = assignmentOperation.Target switch
         {
-            IPropertyReferenceOperation propertyReference => (ISymbol)propertyReference.Property,
-            IFieldReferenceOperation fieldReference => (ISymbol)fieldReference.Field,
+            IPropertyReferenceOperation propertyReference => propertyReference.Property,
+            IFieldReferenceOperation fieldReference => fieldReference.Field,
             _ => null
         };
 
@@ -113,7 +113,7 @@ public class UseStaticLambdaOrMethodAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeLambdaAssignment(OperationAnalysisContext context, IOperation value, ISymbol symbol, AttributeData attribute)
     {
-        if (value is IAnonymousFunctionOperation lambdaOperation)
+        if (value is IDelegateCreationOperation delegateCreationOperation && delegateCreationOperation.Target is IAnonymousFunctionOperation lambdaOperation)
         {
             if (!lambdaOperation.Symbol.IsStatic)
             {

--- a/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
+++ b/src/SubtleEngineering.Analyzers/UseStaticLambda/UseStaticLambdaOrMethodAnalyzer.cs
@@ -1,0 +1,99 @@
+﻿namespace SubtleEngineering.Analyzers.UseDifferentMethod
+{
+    using System;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.CSharp;
+    using System.Linq;
+    using System.Collections.Immutable;
+    using SubtleEngineering.Analyzers.Decorators;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UseStaticLambdaOrMethodAnalyzer : DiagnosticAnalyzer
+    {
+        private const int SE1060 = 0;
+        private const int SE1061 = 1;
+
+        public static readonly ImmutableArray<DiagnosticDescriptor> Rules = ImmutableArray.Create(
+            new DiagnosticDescriptor(
+                DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticNoReasoning,
+                "Property, field or argument should be a static lambda",
+                "Argument, property or field '{0}' should be declared as static.",
+                "Usage",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true),
+            new DiagnosticDescriptor(
+                DiagnosticsDetails.UseStaticLambdaOrMethod.UseStaticWithReason,
+                "Property, field or argument should be a static lambda",
+                "Argument, property or field '{0}' should be declared as static. Reasoning: {1}",
+                "Usage",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true)
+            );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Rules;
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            // Register a symbol action to analyze fields, properties, and method parameters
+            context.RegisterSymbolAction(AnalyzeMember, SymbolKind.Field, SymbolKind.Property, SymbolKind.Parameter);
+        }
+
+        private static void AnalyzeMember(SymbolAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+            var attributes = symbol.GetAttributes();
+
+            foreach (var attribute in attributes)
+            {
+                if (attribute.AttributeClass?.ToDisplayString() == "SubtleEngineering.Analyzers.Decorators.UseStaticLambdaAttribute")
+                {
+                    if (symbol is IFieldSymbol fieldSymbol && fieldSymbol.Type.TypeKind == TypeKind.Delegate)
+                    {
+                        AnalyzeLambda(fieldSymbol, context, attribute);
+                    }
+                    else if (symbol is IPropertySymbol propertySymbol && propertySymbol.Type.TypeKind == TypeKind.Delegate)
+                    {
+                        AnalyzeLambda(propertySymbol, context, attribute);
+                    }
+                    else if (symbol is IParameterSymbol parameterSymbol && parameterSymbol.Type.TypeKind == TypeKind.Delegate)
+                    {
+                        AnalyzeLambda(parameterSymbol, context, attribute);
+                    }
+
+                    return;
+                }
+            }
+        }
+
+        private static void AnalyzeLambda(ISymbol symbol, SymbolAnalysisContext context, AttributeData attribute)
+        {
+            var reasonArg = attribute.ConstructorArguments.Length > 0 ? attribute.ConstructorArguments[0].Value?.ToString() : null;
+            var diagnosticDescriptor = reasonArg != null ? Rules[SE1061] : Rules[SE1060];
+
+            // Check if the lambda assigned is static
+            if (symbol.DeclaringSyntaxReferences.Length > 0)
+            {
+                var syntax = symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
+                if (syntax is VariableDeclaratorSyntax variableDeclarator)
+                {
+                    var initializer = variableDeclarator.Initializer?.Value;
+                    if (initializer is SimpleLambdaExpressionSyntax lambdaExpression && !lambdaExpression.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    {
+                        var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                    else if (initializer is ParenthesizedLambdaExpressionSyntax parenthesizedLambda && !parenthesizedLambda.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    {
+                        var diagnostic = Diagnostic.Create(diagnosticDescriptor, symbol.Locations[0], symbol.Name, reasonArg);
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Code quality: Warn against using non-static lambdas (SE106X)

For performance-sensitive code, it's sometimes useful for the developer to prevent misuse of a method or class to protect the developer.

Using the [UseStaticLambda] on a field, property or parameter will cause the analyzer to emit a warning if a non-static lambda is passed in.

```csharp
public ref struct MyOptimizedNonAllocUtility
{
	public MyOptimizedNonAllocUtility([UseStaticLambda] Func<int> myDelegate)
	{
		_myDelegate = myDelegate;
	}
}

// Code using the struct
var s = new MyOptimizedNonAllocUtility(() => 42); // This will emit SE1060

// Fixed code:
var s = new MyOptimizedNonAllocUtility(static () => 42); // This will emit SE1060


```

#### SE1060/SE1061

**What it looks for**: Passing in non-static delegates to methods that expect to get a static.

**Why**: For performance-sensitive code that uses delegates, it's easy to sometimes forget that creating a capturing delegate can be expensive. This will remind the developer to use a delegate that will not allocate or allocate less.

**How it helps engineers**: Reduces the chance of making such mistakes.



